### PR TITLE
exit without stacktrace on Interactive Mode on Ctrl+C or Ctrl+D

### DIFF
--- a/src/main/java/com/github/imas/rdflint/RdfLint.java
+++ b/src/main/java/com/github/imas/rdflint/RdfLint.java
@@ -33,9 +33,11 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFParser;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.Parser;
+import org.jline.reader.UserInterruptException;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.thymeleaf.TemplateEngine;
@@ -234,7 +236,13 @@ public class RdfLint {
         .build();
 
     while (true) {
-      String line = lineReader.readLine("SPARQL> ");
+      String line;
+
+      try {
+        line = lineReader.readLine("SPARQL> ");
+      } catch (UserInterruptException | EndOfFileException e) {
+        return;
+      }
 
       if (line.trim().charAt(0) == ':') {
         // execute command


### PR DESCRIPTION
## Purpose
This PR makes the Interactive Mode to exit on Ctrl+C or Ctrl-D without stacktrace.

## Approach
To catch UserInterruptException and EndOfFileException.

## Learning
[jline 使い方メモ - Qiita](https://qiita.com/opengl-8080/items/0e8ed1a22ace7797f242#%E5%85%A5%E5%8A%9B%E5%BE%85%E6%A9%9F%E4%B8%AD%E3%81%AB-ctrl--c-%E3%82%92%E6%A4%9C%E7%9F%A5%E3%81%99%E3%82%8B)
