### PR TITLE
add ga to gh-pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,4 @@
 theme: jekyll-theme-hacker
 title: "rdflint: RDF Linter"
 description: "RDFデータのチェックツール「rdflint」の利用ガイド"
+google_analytics: UA-150373815-1


### PR DESCRIPTION
## Purpose
for analysis user guide access.

## Approach
add google analytics tag.