### PR TITLE
configurable what is considered an error

### DIFF
--- a/src/main/java/com/github/imas/rdflint/LintProblemSet.java
+++ b/src/main/java/com/github/imas/rdflint/LintProblemSet.java
@@ -30,16 +30,20 @@ public class LintProblemSet {
   /**
    * return error size.
    */
-  public long errorSize() {
+  long errorSize(ErrorLevel minErrorLevel) {
     return problemSet.values().stream()
         .mapToLong(lp -> lp.stream()
-            .filter(t -> t.getLevel() == ErrorLevel.ERROR || t.getLevel() == ErrorLevel.WARN)
+            .filter(t -> t.getLevel().compareTo(minErrorLevel) <= 0)
             .count())
         .sum();
   }
 
   public boolean hasError() {
-    return errorSize() > 0;
+    return errorSize(ErrorLevel.WARN) > 0;
+  }
+
+  public boolean hasProblemOfLevelOrWorse(ErrorLevel minErrorLevel) {
+    return errorSize(minErrorLevel) > 0;
   }
 
   public Map<String, List<LintProblem>> getProblemSet() {

--- a/src/main/java/com/github/imas/rdflint/RdfLint.java
+++ b/src/main/java/com/github/imas/rdflint/RdfLint.java
@@ -68,6 +68,7 @@ public class RdfLint {
     options.addOption("origindir", true, "Origin Dataset Directory Path");
     options.addOption("config", true, "Configuration file Path");
     options.addOption("suppress", true, "Suppress problems file Path");
+    options.addOption("minErrorLevel", true, "Minimal logging level which is considered an error, e.g. INFO, WARN, ERROR");
     options.addOption("i", false, "Interactive mode");
     options.addOption("ls", false, "Language Server mode (experimental)");
     options.addOption("h", false, "Print usage");
@@ -142,7 +143,9 @@ public class RdfLint {
         Path problemsPath = Paths.get(params.getOutputDir() + "/rdflint-problems.yml");
         LintProblemFormatter.out(System.out, problems);
         LintProblemFormatter.yaml(Files.newOutputStream(problemsPath), problems);
-        if (problems.hasError()) {
+        final String minErrorLevel = cmd.getOptionValue("minErrorLevel","WARN");
+        final LintProblem.ErrorLevel errorLevel = LintProblem.ErrorLevel.valueOf(minErrorLevel);
+        if (problems.hasProblemOfLevelOrWorse(errorLevel)) {
           System.exit(1);
         }
       }

--- a/src/main/java/com/github/imas/rdflint/RdfLint.java
+++ b/src/main/java/com/github/imas/rdflint/RdfLint.java
@@ -68,7 +68,8 @@ public class RdfLint {
     options.addOption("origindir", true, "Origin Dataset Directory Path");
     options.addOption("config", true, "Configuration file Path");
     options.addOption("suppress", true, "Suppress problems file Path");
-    options.addOption("minErrorLevel", true, "Minimal logging level which is considered an error, e.g. INFO, WARN, ERROR");
+    options.addOption("minErrorLevel", true,
+        "Minimal logging level which is considered an error, e.g. INFO, WARN, ERROR");
     options.addOption("i", false, "Interactive mode");
     options.addOption("ls", false, "Language Server mode (experimental)");
     options.addOption("h", false, "Print usage");

--- a/src/test/java/com/github/imas/rdflint/LintProblemSetTest.java
+++ b/src/test/java/com/github/imas/rdflint/LintProblemSetTest.java
@@ -1,16 +1,16 @@
 package com.github.imas.rdflint;
 
-import com.github.imas.rdflint.validator.RdfValidator;
-import org.junit.Test;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import com.github.imas.rdflint.validator.RdfValidator;
+import org.junit.Test;
 
 public class LintProblemSetTest {
 
   @Test public void minimalErrorLevelCorrectlyUsed() {
     LintProblemSet problemSet = new LintProblemSet();
-    RdfValidator v= null;
+    RdfValidator v = null;
     LintProblemLocation location = null;
     String key = null;
     String fileName = "";

--- a/src/test/java/com/github/imas/rdflint/LintProblemSetTest.java
+++ b/src/test/java/com/github/imas/rdflint/LintProblemSetTest.java
@@ -3,25 +3,25 @@ package com.github.imas.rdflint;
 import com.github.imas.rdflint.validator.RdfValidator;
 import org.junit.Test;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class LintProblemSetTest {
 
-  @Test public void minimalErrorLevelCorrectlyUsed() throws Exception {
+  @Test public void minimalErrorLevelCorrectlyUsed() {
     LintProblemSet problemSet = new LintProblemSet();
-    RdfValidator validator= null;
+    RdfValidator v= null;
     LintProblemLocation location = null;
     String key = null;
     String fileName = "";
-    problemSet.addProblem(fileName, new LintProblem(LintProblem.ErrorLevel.WARN, validator,location,key));
-    assertFalse( problemSet.hasProblemOfLevelOrWorse(LintProblem.ErrorLevel.ERROR));
-    assertTrue( problemSet.hasProblemOfLevelOrWorse(LintProblem.ErrorLevel.WARN));
+    problemSet.addProblem(fileName, new LintProblem(LintProblem.ErrorLevel.WARN, v,location,key));
+    assertFalse(problemSet.hasProblemOfLevelOrWorse(LintProblem.ErrorLevel.ERROR));
+    assertTrue(problemSet.hasProblemOfLevelOrWorse(LintProblem.ErrorLevel.WARN));
 
-    problemSet.addProblem(fileName, new LintProblem(LintProblem.ErrorLevel.INFO, validator,location,key));
-    assertFalse( problemSet.hasProblemOfLevelOrWorse(LintProblem.ErrorLevel.ERROR));
+    problemSet.addProblem(fileName, new LintProblem(LintProblem.ErrorLevel.INFO, v,location,key));
+    assertFalse(problemSet.hasProblemOfLevelOrWorse(LintProblem.ErrorLevel.ERROR));
 
-    problemSet.addProblem(fileName, new LintProblem(LintProblem.ErrorLevel.ERROR, validator,location,key));
-    assertTrue( problemSet.hasProblemOfLevelOrWorse(LintProblem.ErrorLevel.ERROR));
+    problemSet.addProblem(fileName, new LintProblem(LintProblem.ErrorLevel.ERROR, v,location,key));
+    assertTrue(problemSet.hasProblemOfLevelOrWorse(LintProblem.ErrorLevel.ERROR));
   }
 }

--- a/src/test/java/com/github/imas/rdflint/LintProblemSetTest.java
+++ b/src/test/java/com/github/imas/rdflint/LintProblemSetTest.java
@@ -1,0 +1,27 @@
+package com.github.imas.rdflint;
+
+import com.github.imas.rdflint.validator.RdfValidator;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+public class LintProblemSetTest {
+
+  @Test public void minimalErrorLevelCorrectlyUsed() throws Exception {
+    LintProblemSet problemSet = new LintProblemSet();
+    RdfValidator validator= null;
+    LintProblemLocation location = null;
+    String key = null;
+    String fileName = "";
+    problemSet.addProblem(fileName, new LintProblem(LintProblem.ErrorLevel.WARN, validator,location,key));
+    assertFalse( problemSet.hasProblemOfLevelOrWorse(LintProblem.ErrorLevel.ERROR));
+    assertTrue( problemSet.hasProblemOfLevelOrWorse(LintProblem.ErrorLevel.WARN));
+
+    problemSet.addProblem(fileName, new LintProblem(LintProblem.ErrorLevel.INFO, validator,location,key));
+    assertFalse( problemSet.hasProblemOfLevelOrWorse(LintProblem.ErrorLevel.ERROR));
+
+    problemSet.addProblem(fileName, new LintProblem(LintProblem.ErrorLevel.ERROR, validator,location,key));
+    assertTrue( problemSet.hasProblemOfLevelOrWorse(LintProblem.ErrorLevel.ERROR));
+  }
+}


### PR DESCRIPTION
## Purpose
Currently WARN and ERROR problems make the lint fail.

## Approach
Introduced a novel parameter minErrorLevel which allows to configure the minimal level to be considered an error.