### PR TITLE
bugfix: invalid ttl file validation exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,10 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '4.0.3'
     id "com.github.spotbugs" version "3.0.0"
 }
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
     jcenter()

--- a/src/main/java/com/github/imas/rdflint/validator/impl/RdfSyntaxValidator.java
+++ b/src/main/java/com/github/imas/rdflint/validator/impl/RdfSyntaxValidator.java
@@ -62,7 +62,11 @@ public class RdfSyntaxValidator extends AbstractRdfValidator {
         .base(baseUri + subdir)
         .errorHandler(new RdfLintSyntaxErrorHandler(problems, filename, this))
         .build();
-    parser.parse(g);
+    try {
+      parser.parse(g);
+    } catch (Exception ex) {
+      // no action: because exceptions recorded to problem variable
+    }
     g.close();
   }
 

--- a/src/test/resources/testValidatorsImpl/RdfSyntaxValidator/turtle_invalid/expected-problems.yml
+++ b/src/test/resources/testValidatorsImpl/RdfSyntaxValidator/turtle_invalid/expected-problems.yml
@@ -1,0 +1,5 @@
+invalidturtle.ttl:
+  - key: com.github.imas.rdflint.validator.impl.parseError
+    line: 8
+    column: 5
+

--- a/src/test/resources/testValidatorsImpl/RdfSyntaxValidator/turtle_invalid/invalidturtle.ttl
+++ b/src/test/resources/testValidatorsImpl/RdfSyntaxValidator/turtle_invalid/invalidturtle.ttl
@@ -1,0 +1,8 @@
+@base <http://example.com/> .
+@prefix schema: <http://schema.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+<something>
+    a <http://example.com/rdflint#someclass> ;
+    schem:familyName "familyName" .

--- a/src/test/resources/testValidatorsImpl/RdfSyntaxValidator/turtle_invalid/rdflint-config.yml
+++ b/src/test/resources/testValidatorsImpl/RdfSyntaxValidator/turtle_invalid/rdflint-config.yml
@@ -1,0 +1,1 @@
+baseUri: http://example.com/rdflint#


### PR DESCRIPTION
## Purpose
fix issue. ref #116

## Approach
Add exception handling at file syntax validation.
In the case of RDFXML, exception is not thrown when the parser parse invalid xml,
but invalid ttl brings NullPointerException.
testcases is not sufficient, and add testcase.
