### PR TITLE
vscode-rdflint: add lsp enable/disable configuration

### DIFF
--- a/vscode-rdflint/CHANGELOG.md
+++ b/vscode-rdflint/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+- Language Server Protocol enable/disable configuration.
+
 ## 0.0.4
 
 - Work with rdflint over Language Server Protocol.

--- a/vscode-rdflint/README.md
+++ b/vscode-rdflint/README.md
@@ -12,6 +12,11 @@ Provides RDF language support via [rdflint](https://github.com/imas/rdflint).
 - Shift+Cmd+P and select `rdflint Interactive Mode: SPARQL playground`.
    - You can find the command, with type substring like 'rdflint', 'SPARQL', etc.
 
+### How to enable Rdflint Language Server
+
+- Open Settings, and check 'Extentions > Rdflint Language Server > Enable rdflint language server'
+- Shift+Cmd+P and type `Reload Window`
+
 ## Features
 
 - rdflint validations.

--- a/vscode-rdflint/package.json
+++ b/vscode-rdflint/package.json
@@ -70,8 +70,14 @@
 		],
 		"configuration": {
 			"type": "object",
-			"title": "RdflintLanguageServer configuration",
+			"title": "Rdflint Language Server",
 			"properties": {
+				"rdflintLanguageServer.enable": {
+					"scope": "window",
+					"type": "boolean",
+					"default": false,
+					"description": "Enable rdflint language server. (Experimental)"
+				},
 				"rdflintLanguageServer.trace.server": {
 					"scope": "window",
 					"type": "string",


### PR DESCRIPTION
## Purpose
add lsp enable/disable configuration, because Rdflint language server is experimental.

## Approach
add checkbox to extention configuration.