### PR TITLE
Fix startup error of language server when no config file is there

### DIFF
--- a/src/main/java/com/github/imas/rdflint/ConfigurationLoader.java
+++ b/src/main/java/com/github/imas/rdflint/ConfigurationLoader.java
@@ -19,7 +19,7 @@ public class ConfigurationLoader {
 
   private static final Logger logger = Logger.getLogger(ConfigurationLoader.class.getName());
 
-  protected static final List<String> CONFIG_SEARCH_PATH = Collections
+  private static final List<String> CONFIG_SEARCH_PATH = Collections
       .unmodifiableList(Arrays.asList(
           "rdflint-config.yml",
           ".rdflint-config.yml",
@@ -27,7 +27,7 @@ public class ConfigurationLoader {
           "config/rdflint/rdflint-config.yml",
           ".circleci/rdflint-config.yml"
       ));
-  protected static final List<String> SUPPRESS_SEARCH_PATH = Collections
+  private static final List<String> SUPPRESS_SEARCH_PATH = Collections
       .unmodifiableList(Arrays.asList(
           "rdflint-suppress.yml",
           ".rdflint-suppress.yml",
@@ -44,13 +44,7 @@ public class ConfigurationLoader {
     String configPath = cmdOptions.get("config");
     String parentPath = targetDir != null ? targetDir : ".";
     if (configPath == null) {
-      for (String fn : CONFIG_SEARCH_PATH) {
-        Path path = Paths.get(parentPath + "/" + fn);
-        if (Files.exists(path)) {
-          configPath = path.toAbsolutePath().toString();
-          break;
-        }
-      }
+      configPath = searchConfigPath(parentPath);
     }
     RdfLintParameters params = loadConfig(configPath);
     setupParameters(params, targetDir, parentPath, cmdOptions);
@@ -63,13 +57,7 @@ public class ConfigurationLoader {
       Map<String, String> cmdOptions) {
     String suppressPath = cmdOptions.get("suppress");
     if (suppressPath == null) {
-      for (String fn : SUPPRESS_SEARCH_PATH) {
-        Path path = Paths.get(parentPath + "/" + fn);
-        if (Files.exists(path)) {
-          suppressPath = path.toAbsolutePath().toString();
-          break;
-        }
-      }
+      suppressPath = searchSuppressPath(parentPath);
     }
 
     if (targetDir != null) {
@@ -96,6 +84,26 @@ public class ConfigurationLoader {
     if (suppressPath != null) {
       params.setSuppressPath(suppressPath);
     }
+  }
+
+  protected static String searchConfigPath(String parentPath) {
+    for (String fn : CONFIG_SEARCH_PATH) {
+      Path path = Paths.get(parentPath + "/" + fn);
+      if (Files.exists(path)) {
+        return path.toAbsolutePath().toString();
+      }
+    }
+    return null;
+  }
+
+  protected static String searchSuppressPath(String parentPath) {
+    for (String fn : SUPPRESS_SEARCH_PATH) {
+      Path path = Paths.get(parentPath + "/" + fn);
+      if (Files.exists(path)) {
+        return path.toAbsolutePath().toString();
+      }
+    }
+    return null;
   }
 
   /**

--- a/src/main/java/com/github/imas/rdflint/RdfLintLanguageServer.java
+++ b/src/main/java/com/github/imas/rdflint/RdfLintLanguageServer.java
@@ -119,7 +119,7 @@ public class RdfLintLanguageServer implements LanguageServer, LanguageClientAwar
   public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
     // initialize rdflint
     String rootPath = convertUri2FilePath(params.getRootUri());
-    String configPath = "";
+    String configPath = null;
     for (String fn : ConfigurationLoader.CONFIG_SEARCH_PATH) {
       Path path = Paths.get(rootPath + "/" + fn);
       if (Files.exists(path)) {

--- a/src/main/java/com/github/imas/rdflint/RdfLintLanguageServer.java
+++ b/src/main/java/com/github/imas/rdflint/RdfLintLanguageServer.java
@@ -15,7 +15,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -119,26 +118,13 @@ public class RdfLintLanguageServer implements LanguageServer, LanguageClientAwar
   public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
     // initialize rdflint
     String rootPath = convertUri2FilePath(params.getRootUri());
-    String configPath = null;
-    for (String fn : ConfigurationLoader.CONFIG_SEARCH_PATH) {
-      Path path = Paths.get(rootPath + "/" + fn);
-      if (Files.exists(path)) {
-        configPath = path.toAbsolutePath().toString();
-        break;
-      }
-    }
+    String configPath = ConfigurationLoader.searchConfigPath(rootPath);
     try {
       rdflintParams = ConfigurationLoader.loadConfig(configPath);
       rdflintParams.setTargetDir(rootPath);
       rdflintParams.setOutputDir(rootPath);
       if (rdflintParams.getSuppressPath() == null) {
-        for (String fn : ConfigurationLoader.SUPPRESS_SEARCH_PATH) {
-          Path path = Paths.get(rootPath + "/" + fn);
-          if (Files.exists(path)) {
-            rdflintParams.setSuppressPath(path.toAbsolutePath().toString());
-            break;
-          }
-        }
+        rdflintParams.setSuppressPath(ConfigurationLoader.searchSuppressPath(rootPath));
       }
     } catch (IOException ex) {
       showException("Error cannot initialize rdflint", ex);


### PR DESCRIPTION
## Purpose

This PR fixes an issue where rdflint language server throws an unhandled exception `java.io.IOException: Is a directory` on startup when there is no config in the workspace.

## Approach

The root of the issue is that `RdfLintLanguageServer.initialize()` passes an empty string ([RdfLintLanguageServer.java:122]) to `ConfigurationLoader.loadConfig`, which, in turn, tries to open the empty path (i.e., the working directory) as a file.

[RdfLintLanguageServer.java:122]: https://github.com/imas/rdflint/blob/d3ad017/src/main/java/com/github/imas/rdflint/RdfLintLanguageServer.java#L122

This PR fixes the issue by making `initialize` pass `null` (instead of an empty string) to `loadConfig`, which then returns an empty `RdfLintParameters` as expected (same behavior as `ConfigurationLoader.loadParameters`).

This change also involves a minor refactoring of relevant code to make the intent clearer.