### PR TITLE
upgrade depends libraries (jena 4.5)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,10 @@ jobs:
       - name: Prepare git
         run: git config --global core.autocrlf false
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '8'
+          java-version: '11'
       - uses: actions/setup-node@v1
         with:
           node-version: '12'

--- a/build.gradle
+++ b/build.gradle
@@ -4,33 +4,33 @@ plugins {
     id 'pmd'
     id 'jacoco'
     id 'com.github.johnrengelman.shadow' version '4.0.3'
-    id 'com.github.spotbugs' version '4.0.5'
+    id 'com.github.spotbugs' version '4.7.0'
 }
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 repositories {
     mavenCentral()
 }
 dependencies {
-    implementation 'org.apache.jena:jena-arq:3.4.0'
-    implementation 'commons-cli:commons-cli:1.4'
+    implementation 'org.apache.jena:jena-arq:4.5.0'
+    implementation 'commons-cli:commons-cli:1.5.0'
     implementation 'org.jline:jline:3.21.0'
-    implementation 'org.yaml:snakeyaml:1.23'
-    implementation 'org.codehaus.groovy:groovy:3.0.0-rc-3'
+    implementation 'org.yaml:snakeyaml:1.30'
+    implementation 'org.codehaus.groovy:groovy:3.0.10'
     implementation 'org.slf4j:slf4j-log4j12:1.7.25'
-    implementation 'org.thymeleaf:thymeleaf:3.0.11.RELEASE'
+    implementation 'org.thymeleaf:thymeleaf:3.0.15.RELEASE'
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:2.2.2'
-    implementation 'org.reflections:reflections:0.9.11'
+    implementation 'org.reflections:reflections:0.10.2'
     implementation 'com.github.albfernandez:juniversalchardet:2.3.0'
-    implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.8.1'
-    implementation group: 'org.topbraid', name: 'shacl', version: '1.3.0'
+    implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0'
+    implementation 'org.topbraid:shacl:1.3.0'
 
     compileOnly 'net.jcip:jcip-annotations:1.0'
-    compileOnly 'com.github.spotbugs:spotbugs:4.0.2'
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.0.2'
+    compileOnly 'com.github.spotbugs:spotbugs:4.7.0'
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.0'
 
     testImplementation 'junit:junit:4.+'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
@@ -62,7 +62,7 @@ pmd {
     ]
 }
 spotbugs {
-    toolVersion = '4.0.2'
+    toolVersion = '4.2.1'
 }
 jacocoTestCoverageVerification {
     violationRules {
@@ -75,8 +75,8 @@ jacocoTestCoverageVerification {
 }
 tasks.withType(Checkstyle) {
     reports {
-        xml.enabled = false
-        html.enabled = true
+        xml.enabled(false)
+        html.enabled(true)
     }
 }
 tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+  - sdk install java 11.0.10-open
+  - sdk use java 11.0.10-open

--- a/src/main/java/com/github/imas/rdflint/parser/RdflintParserBuilder.java
+++ b/src/main/java/com/github/imas/rdflint/parser/RdflintParserBuilder.java
@@ -72,7 +72,7 @@ public class RdflintParserBuilder {
     if (this.lang == Lang.RDFXML) {
       return new RdflintParserRdfxml(this.body, this.validators, this.base);
     }
-    return new RdflintParserTurtle(this.body, this.validators);
+    return new RdflintParserTurtle(this.body, this.validators, this.base);
   }
 
 }

--- a/src/main/java/com/github/imas/rdflint/parser/RdflintParserTurtle.java
+++ b/src/main/java/com/github/imas/rdflint/parser/RdflintParserTurtle.java
@@ -12,6 +12,7 @@ import org.apache.jena.atlas.web.ContentType;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.irix.IRIxResolver;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFParserRegistry;
@@ -20,7 +21,6 @@ import org.apache.jena.riot.ReaderRIOTFactory;
 import org.apache.jena.riot.RiotParseException;
 import org.apache.jena.riot.system.ErrorHandler;
 import org.apache.jena.riot.system.FactoryRDF;
-import org.apache.jena.riot.system.IRIResolver;
 import org.apache.jena.riot.system.ParserProfileStd;
 import org.apache.jena.riot.system.PrefixMap;
 import org.apache.jena.riot.system.PrefixMapFactory;
@@ -40,7 +40,7 @@ public class RdflintParserTurtle extends RdflintParser {
     List<LintProblem> diagnosticList;
     List<RdfValidator> validationModels;
 
-    public RdflintParseProfile(FactoryRDF factory, ErrorHandler errorHandler, IRIResolver resolver,
+    public RdflintParseProfile(FactoryRDF factory, ErrorHandler errorHandler, IRIxResolver resolver,
         PrefixMap prefixMap, Context context, boolean checking, boolean strictMode,
         List<RdfValidator> validationModels, List<LintProblem> diagnosticList) {
       super(factory, errorHandler, resolver, prefixMap, context, checking, strictMode);
@@ -101,14 +101,16 @@ public class RdflintParserTurtle extends RdflintParser {
 
   String text;
   List<RdfValidator> validators;
+  String base;
 
   /**
    * constructor.
    */
-  public RdflintParserTurtle(String text, List<RdfValidator> validators) {
+  public RdflintParserTurtle(String text, List<RdfValidator> validators, String base) {
     super();
     this.text = text;
     this.validators = validators;
+    this.base = base;
   }
 
   @Override
@@ -118,8 +120,8 @@ public class RdflintParserTurtle extends RdflintParser {
     try {
       // validation
       FactoryRDF factory = RiotLib.factoryRDF();
-      IRIResolver resolver = IRIResolver.create();
-      PrefixMap prefixMap = PrefixMapFactory.createForInput();
+      IRIxResolver resolver = IRIxResolver.create().base(this.base).build();
+      PrefixMap prefixMap = PrefixMapFactory.create();
       Context context = new Context();
       boolean checking = true;
       boolean strict = false;

--- a/src/test/java/com/github/imas/rdflint/parser/RdflintParserTurtleTest.java
+++ b/src/test/java/com/github/imas/rdflint/parser/RdflintParserTurtleTest.java
@@ -24,7 +24,10 @@ public class RdflintParserTurtleTest {
 
     Graph g = Factory.createGraphMem();
     List<LintProblem> problems = new LinkedList<>();
-    RdflintParser.source(Paths.get(rootPath)).lang(Lang.TURTLE).parse(g, problems);
+    RdflintParser.source(Paths.get(rootPath))
+        .lang(Lang.TURTLE)
+        .base("http://example.com/")
+        .parse(g, problems);
 
     assertFalse(g.size() == 0);
     g.close();
@@ -37,7 +40,10 @@ public class RdflintParserTurtleTest {
 
     Graph g = Factory.createGraphMem();
     List<LintProblem> problems = new LinkedList<>();
-    RdflintParser.source(Paths.get(rootPath)).lang(Lang.TURTLE).parse(g, problems);
+    RdflintParser.source(Paths.get(rootPath))
+        .lang(Lang.TURTLE)
+        .base("http://example.com/")
+        .parse(g, problems);
 
     g.close();
     assertFalse(problems.size() == 0);
@@ -56,6 +62,7 @@ public class RdflintParserTurtleTest {
     List<LintProblem> problems = new LinkedList<>();
     RdflintParser.source(Paths.get(rootPath))
         .lang(Lang.TURTLE)
+        .base("http://example.com/")
         .validators(validators)
         .parse(g, problems);
 


### PR DESCRIPTION
## Purpose
_Describe the problem or feature in addition to a link to the issues._
upgrade depends libraries
- jena: 3.4 -> 4.5
- java: 1.8 -> 11

fix #136

## Approach
_How does this change address the problem?_
- change dependent library versions (build.gradle)
- fix compatibility problems