### PR TITLE
add github annotations

### DIFF
--- a/src/main/java/com/github/imas/rdflint/LintProblemFormatter.java
+++ b/src/main/java/com/github/imas/rdflint/LintProblemFormatter.java
@@ -1,5 +1,6 @@
 package com.github.imas.rdflint;
 
+import com.github.imas.rdflint.LintProblem.ErrorLevel;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.OutputStream;
 import java.io.PrintWriter;
@@ -72,6 +73,42 @@ public class LintProblemFormatter {
         Object[] args = LintProblemFormatter.buildArguments(m);
         String msg = LintProblemFormatter.dumpMessage(m.getKey(), null, args);
         pw.println("  " + m.getLevel() + "  " + msg);
+      });
+      pw.println();
+    });
+    pw.flush();
+  }
+
+  /**
+   * dump formatted problems.
+   */
+  @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING")
+  public static void annotationGitHubAction(OutputStream out, LintProblemSet problems) {
+    PrintWriter pw = new PrintWriter(out);
+    problems.getProblemSet().forEach((f, l) -> {
+      l.forEach(m -> {
+        Object[] args = LintProblemFormatter.buildArguments(m);
+        String msg = LintProblemFormatter.dumpMessage(m.getKey(), null, args);
+        long lineNoBegin = 1;
+        long lineNoEnd = 1;
+        if (m.getLocation() != null && m.getLocation().getBeginLine() >= 0) {
+          lineNoBegin = m.getLocation().getBeginLine();
+          if (m.getLocation().getEndLine() >= 0) {
+            lineNoEnd = m.getLocation().getEndLine();
+          } else {
+            lineNoEnd = lineNoBegin;
+          }
+        }
+        pw.println(String.format(
+            "::%s file=%s,line=%d,endLine=%d,title=%s#L%d::%s",
+            m.getLevel() == ErrorLevel.INFO ? "warning" : "error",
+            f,
+            lineNoBegin,
+            lineNoEnd,
+            f,
+            lineNoBegin,
+            msg
+        ));
       });
       pw.println();
     });

--- a/src/main/java/com/github/imas/rdflint/RdfLint.java
+++ b/src/main/java/com/github/imas/rdflint/RdfLint.java
@@ -109,6 +109,9 @@ public class RdfLint {
       if (problems.hasProblem()) {
         Path problemsPath = Paths.get(params.getOutputDir() + "/rdflint-problems.yml");
         LintProblemFormatter.out(System.out, problems);
+        if ("true".equals(System.getenv("GITHUB_ACTIONS"))) {
+          LintProblemFormatter.annotationGitHubAction(System.out, problems);
+        }
         LintProblemFormatter.yaml(Files.newOutputStream(problemsPath), problems);
         final String minErrorLevel = cmd.getOptionValue("minErrorLevel", "WARN");
         final LintProblem.ErrorLevel errorLevel = LintProblem.ErrorLevel.valueOf(minErrorLevel);


### PR DESCRIPTION
## Purpose
_Describe the problem or feature in addition to a link to the issues._
Support github annotations.

Annotations image:
![gh_annotations](https://user-images.githubusercontent.com/1129652/170853955-4aaf604a-f75d-4fdf-9422-acc2b7f45c78.png)

## Approach
_How does this change address the problem?_
Add workflow command output for github annotations, when rdflint run in GitHub Actions.

## Learning
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

Workflow commands for GitHub Annotations
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
- Setting a warning message
- Setting an error message

GitHub Actions environment variables: GITHUB_ACTIONS=true
https://docs.github.com/ja/actions/learn-github-actions/environment-variables
